### PR TITLE
Fix navigation flow to show episodes

### DIFF
--- a/src/AppNavigator.tsx
+++ b/src/AppNavigator.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import HomeScreen from './screens/Home';
+import SeasonsScreen from './screens/Seasons';
 import EpisodesScreen from './screens/Episodes';
 import StreamsScreen from './screens/Streams';
 
 export type RootStackParamList = {
   Home: undefined;
-  Episodes: { imdbId: string; title: string; seasons: number };
+  Seasons: { imdbId: string; title: string };
+  Episodes: { imdbId: string; season: number; title: string };
   Streams: {
     imdbId: string; season: number; episode: number; title: string;
   };
@@ -19,6 +21,7 @@ export default function StackNav() {
   return (
     <Stack.Navigator screenOptions={{ headerShown: true }}>
         <Stack.Screen name="Home" component={HomeScreen} />
+        <Stack.Screen name="Seasons" component={SeasonsScreen} />
         <Stack.Screen name="Episodes" component={EpisodesScreen} />
         <Stack.Screen name="Streams" component={StreamsScreen} />
       </Stack.Navigator>

--- a/src/api/cinemeta.ts
+++ b/src/api/cinemeta.ts
@@ -30,3 +30,14 @@ export async function getSeriesMeta(imdbId: string) {
 export function extractSeasons(meta: Awaited<ReturnType<typeof getSeriesMeta>>) {
   return Array.from(new Set(meta.videos.map(v => v.season))).sort((a, b) => a - b);
 }
+
+/** Returns episodes of a season sorted by episode number */
+export function extractEpisodes(
+  meta: Awaited<ReturnType<typeof getSeriesMeta>>,
+  season: number
+) {
+  return meta.videos
+    .filter(v => v.season === season)
+    .sort((a, b) => a.episode - b.episode)
+    .map(v => ({ episode: v.episode, title: v.title }));
+}

--- a/src/screens/Episodes.tsx
+++ b/src/screens/Episodes.tsx
@@ -2,40 +2,44 @@ import React, { useEffect, useState } from 'react';
 import { FlatList, TouchableOpacity, Text } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../AppNavigator';
-import { getSeriesMeta, extractSeasons } from '../api/cinemeta';
+import { getSeriesMeta, extractEpisodes } from '../api/cinemeta';
 
-type Props = NativeStackScreenProps<RootStackParamList, 'Episodes'>;
+// Screen that shows the list of episodes for a given season
+// and navigates to Streams with the correct episode number.
 
-export default function EpisodesScreen({ route, navigation }: Props) {
-  const { imdbId, title } = route.params;
-  const [seasons, setSeasons] = useState<number[]>([]);
+export type EpisodesScreenProps = NativeStackScreenProps<RootStackParamList, 'Episodes'>;
+
+export default function EpisodesScreen({ route, navigation }: EpisodesScreenProps) {
+  const { imdbId, season, title } = route.params;
+  const [episodes, setEpisodes] = useState<{ episode: number; title: string }[]>([]);
 
   useEffect(() => {
-    getSeriesMeta(imdbId).then(meta => setSeasons(extractSeasons(meta)));
+    getSeriesMeta(imdbId).then(meta => setEpisodes(extractEpisodes(meta, season)));
   }, []);
 
   return (
     <FlatList
       style={{ backgroundColor: '#121212' }}
-      data={seasons}
-      keyExtractor={n => n.toString()}
-      renderItem={({ item: season }) => (
+      data={episodes}
+      keyExtractor={e => e.episode.toString()}
+      renderItem={({ item }) => (
         <TouchableOpacity
           style={{ padding: 16, borderBottomWidth: 1, borderColor: '#333' }}
           onPress={() =>
             navigation.navigate('Streams', {
               imdbId,
               season,
-              episode: 1,
-              title: `${title} · S${season}`
+              episode: item.episode,
+              title: `${title} · E${item.episode}`,
             })
           }
         >
-          <Text style={{ color: '#fff' }}>Season {season}</Text>
+          <Text style={{ color: '#fff' }}>{`E${item.episode} · ${item.title}`}</Text>
         </TouchableOpacity>
       )}
+      ListHeaderComponent={<Text style={{ color: '#aaa', padding: 16 }}>{title}</Text>}
       ListEmptyComponent={
-        <Text style={{ color: '#999', padding: 16 }}>Loading seasons…</Text>
+        <Text style={{ color: '#999', padding: 16 }}>Loading episodes…</Text>
       }
     />
   );

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -38,10 +38,9 @@ export default function HomeScreen({ navigation }: Props) {
                     <TouchableOpacity
                         style={{ flexDirection: 'row', padding: 10 }}
                         onPress={() =>
-                            navigation.navigate('Episodes', {
+                            navigation.navigate('Seasons', {
                                 imdbId: item.id,
                                 title: item.name,
-                                seasons: item.seasons || 1
                             })
                         }
                     >

--- a/src/screens/Seasons.tsx
+++ b/src/screens/Seasons.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from 'react';
+import { FlatList, TouchableOpacity, Text } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../AppNavigator';
+import { getSeriesMeta, extractSeasons } from '../api/cinemeta';
+
+type Props = NativeStackScreenProps<RootStackParamList, 'Seasons'>;
+export default function SeasonsScreen({ route, navigation }: Props) {
+  const { imdbId, title } = route.params;
+  const [seasons, setSeasons] = useState<number[]>([]);
+
+  useEffect(() => {
+    getSeriesMeta(imdbId).then(meta => setSeasons(extractSeasons(meta)));
+  }, []);
+
+  return (
+    <FlatList
+      style={{ backgroundColor: '#121212' }}
+      data={seasons}
+      keyExtractor={n => n.toString()}
+      renderItem={({ item: season }) => (
+        <TouchableOpacity
+          style={{ padding: 16, borderBottomWidth: 1, borderColor: '#333' }}
+          onPress={() =>
+            navigation.navigate('Episodes', {
+              imdbId,
+              season,
+              title: `${title} · S${season}`
+            })
+          }
+        >
+          <Text style={{ color: '#fff' }}>Season {season}</Text>
+        </TouchableOpacity>
+      )}
+      ListEmptyComponent={
+        <Text style={{ color: '#999', padding: 16 }}>Loading seasons…</Text>
+      }
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add a new Episodes screen
- rename former Episodes screen to Seasons
- show episodes after choosing a season
- update navigation and API helpers

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684ec60576f483238b998577733962b9