### PR TITLE
Update to TMDB-based API

### DIFF
--- a/src/AppNavigator.tsx
+++ b/src/AppNavigator.tsx
@@ -8,8 +8,8 @@ import StreamsScreen from './screens/Streams';
 
 export type RootStackParamList = {
   Home: undefined;
-  Seasons: { imdbId: string; title: string };
-  Episodes: { imdbId: string; season: number; title: string };
+  Seasons: { imdbId: string; tmdbId: number; title: string };
+  Episodes: { imdbId: string; tmdbId: number; season: number; title: string };
   Streams: {
     imdbId: string; season: number; episode: number; title: string;
   };

--- a/src/api/tmdb.ts
+++ b/src/api/tmdb.ts
@@ -3,18 +3,19 @@ import Constants from 'expo-constants';
 const API = 'https://api.themoviedb.org/3';
 const KEY = Constants.expoConfig?.extra?.tmdbKey || process.env.TMDB_KEY;
 
-/** Busca series y devuelve título + imdbId (si existe) */
+/** Busca series en TMDB y devuelve título, IDs y año */
 export async function searchSeriesTMDB(query: string) {
   const url = `${API}/search/tv?query=${encodeURIComponent(query)}&include_adult=false&language=es-ES&page=1&api_key=${KEY}`;
   const { results } = await fetch(url).then(r => r.json());
 
-  // extrae imdbId para poder usar Torrentio / Peerflix
   const enriched = await Promise.all(
     results.map(async (item: any) => {
       const idsUrl = `${API}/tv/${item.id}/external_ids?api_key=${KEY}`;
       const ids = await fetch(idsUrl).then(r => r.json());
       return {
         id: ids.imdb_id || `tmdb-${item.id}`,
+        imdbId: ids.imdb_id,
+        tmdbId: item.id,
         name: item.name,
         poster: item.poster_path
           ? `https://image.tmdb.org/t/p/w185${item.poster_path}`
@@ -25,7 +26,27 @@ export async function searchSeriesTMDB(query: string) {
   );
 
   // filtra los que NO tengan imdbId (los add-ons de torrents lo necesitan)
-  return enriched.filter(m => m.id.startsWith('tt'));
+  return enriched.filter(m => m.imdbId?.startsWith('tt'));
+}
+
+export async function fetchShow(tmdbId: number) {
+  const url = `${API}/tv/${tmdbId}?language=es-ES&api_key=${KEY}`;
+  return fetch(url).then(r => r.json());
+}
+
+export function extractSeasons(show: Awaited<ReturnType<typeof fetchShow>>) {
+  return (show.seasons ?? [])
+    .filter((s: any) => s.season_number > 0)
+    .map((s: any) => s.season_number)
+    .sort((a: number, b: number) => a - b);
+}
+
+export async function fetchEpisodes(tmdbId: number, season: number) {
+  const data = await fetchSeason(tmdbId, season);
+  return data.episodes?.map((e: any) => ({
+    episode: e.episode_number,
+    title: e.name,
+  })) ?? [];
 }
 
 /** Detalles con temporadas y episodios */

--- a/src/screens/Episodes.tsx
+++ b/src/screens/Episodes.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { FlatList, TouchableOpacity, Text } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../AppNavigator';
-import { getSeriesMeta, extractEpisodes } from '../api/cinemeta';
+import { fetchEpisodes } from '../api/tmdb';
 
 // Screen that shows the list of episodes for a given season
 // and navigates to Streams with the correct episode number.
@@ -10,11 +10,11 @@ import { getSeriesMeta, extractEpisodes } from '../api/cinemeta';
 export type EpisodesScreenProps = NativeStackScreenProps<RootStackParamList, 'Episodes'>;
 
 export default function EpisodesScreen({ route, navigation }: EpisodesScreenProps) {
-  const { imdbId, season, title } = route.params;
+  const { imdbId, tmdbId, season, title } = route.params;
   const [episodes, setEpisodes] = useState<{ episode: number; title: string }[]>([]);
 
   useEffect(() => {
-    getSeriesMeta(imdbId).then(meta => setEpisodes(extractEpisodes(meta, season)));
+    fetchEpisodes(tmdbId, season).then(setEpisodes);
   }, []);
 
   return (

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { FlatList, TouchableOpacity, Text, Image } from 'react-native';
 import SearchBar from '../components/SearchBar';
-import { searchSeries } from '../api/cinemeta';
+import { searchSeriesTMDB } from '../api/tmdb';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../AppNavigator';
 
@@ -16,7 +16,7 @@ export default function HomeScreen({ navigation }: Props) {
         if (t.trim().length < 2) return setResults([]);
 
 
-        const results = await searchSeries(t);
+        const results = await searchSeriesTMDB(t);
         setResults(results);
 
         // const apiResults = await searchSeries(t);
@@ -40,6 +40,7 @@ export default function HomeScreen({ navigation }: Props) {
                         onPress={() =>
                             navigation.navigate('Seasons', {
                                 imdbId: item.id,
+                                tmdbId: item.tmdbId,
                                 title: item.name,
                             })
                         }

--- a/src/screens/Seasons.tsx
+++ b/src/screens/Seasons.tsx
@@ -2,15 +2,15 @@ import React, { useEffect, useState } from 'react';
 import { FlatList, TouchableOpacity, Text } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../AppNavigator';
-import { getSeriesMeta, extractSeasons } from '../api/cinemeta';
+import { fetchShow, extractSeasons } from '../api/tmdb';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Seasons'>;
 export default function SeasonsScreen({ route, navigation }: Props) {
-  const { imdbId, title } = route.params;
+  const { imdbId, tmdbId, title } = route.params;
   const [seasons, setSeasons] = useState<number[]>([]);
 
   useEffect(() => {
-    getSeriesMeta(imdbId).then(meta => setSeasons(extractSeasons(meta)));
+    fetchShow(tmdbId).then(show => setSeasons(extractSeasons(show)));
   }, []);
 
   return (
@@ -24,6 +24,7 @@ export default function SeasonsScreen({ route, navigation }: Props) {
           onPress={() =>
             navigation.navigate('Episodes', {
               imdbId,
+              tmdbId,
               season,
               title: `${title} · S${season}`
             })


### PR DESCRIPTION
## Summary
- fetch series, seasons and episodes from TMDB instead of Cinemeta
- extend navigation params with tmdb id
- update UI flows to use the new tmdb functions

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'expo-status-bar', etc.)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_684ec8c650088323870366f9d0bed7d9