### PR TITLE
Improve stream error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# MagnetCatcher
+
+This Expo/React Native app searches TV shows on TMDB and retrieves torrent streams from several Stremio add-ons. It displays available seasons, episodes and stream links so you can copy the magnet URL.
+
+## Development
+
+```bash
+npm install
+npm start
+```
+
+## Environment Variables
+
+Create a `.env` file based on the following keys:
+
+```
+TMDB_KEY=your_tmdb_api_key
+PEERFLIX_EXTRA=
+TORRENTIO_EXTRA=
+PIRATEBAY_EXTRA=
+ORION_EXTRA=
+MEDIAFUSION_EXTRA=
+```
+
+Some add-ons require tokens or API keys. Provide them in the `*_EXTRA` variables if necessary.
+
+## Network Restrictions
+
+If you see warnings like:
+
+```
+Addon failed https://orion.strem.fun TypeError: Network request failed
+Addon failed https://peerflix.mov SyntaxError: JSON Parse error: Unexpected character: i
+```
+
+it is likely that the add-on domains are blocked or unreachable from your network. The testing environment for this repository blocks those URLs, so no stream options will be listed. Ensure your connection allows requests to the add-on hosts and that the extra tokens are correctly set.

--- a/src/screens/Streams.tsx
+++ b/src/screens/Streams.tsx
@@ -19,14 +19,25 @@ function toMagnet(s: any) {
 export default function StreamsScreen({ route }: Props) {
   const { imdbId, season, episode, title } = route.params;
   const [streams, setStreams] = useState<Stream[]>([]);
+  const [message, setMessage] = useState<string>('No streams yet…');
 
   useEffect(() => {
-    getEpisodeStreams(imdbId, season, episode).then(all => {
-      const filtered = all.filter(s =>
-        s.language === 'es' || s.language === 'en' || s.language === 'multi'
-      );
-      setStreams(filtered);
-    });
+    getEpisodeStreams(imdbId, season, episode)
+      .then(all => {
+        const filtered = all.filter(s =>
+          s.language === 'es' || s.language === 'en' || s.language === 'multi'
+        );
+        setStreams(filtered);
+        if (!filtered.length) {
+          setMessage(
+            'No se encontraron streams. Comprueba la conexión o si los add-ons están bloqueados.'
+          );
+        }
+      })
+      .catch(err => {
+        console.warn('getEpisodeStreams failed', err);
+        setMessage('Error al obtener streams: ' + err?.toString?.());
+      });
   }, []);
 
   async function copy(stream: any) {
@@ -54,7 +65,7 @@ export default function StreamsScreen({ route }: Props) {
         )}
       ListHeaderComponent={<Text style={{ color: '#aaa', padding: 16 }}>{title}</Text>}
       ListEmptyComponent={
-        <Text style={{ color: '#888', padding: 16 }}>No streams yet…</Text>
+        <Text style={{ color: '#888', padding: 16 }}>{message}</Text>
       }
     />
   );


### PR DESCRIPTION
## Summary
- add a README with setup instructions and network restriction notes
- surface fetch errors in Streams screen so the user knows why no streams are displayed

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68505b2f6d9883239f19fe7521edfcff