### PR TITLE
Fix URL encoding for addon stream requests

### DIFF
--- a/src/api/streams.ts
+++ b/src/api/streams.ts
@@ -17,8 +17,11 @@ export async function getEpisodeStreams(
   const collected: Stream[] = [];
 
   const tasks = Object.values(addons).map(async ({ base, extra }) => {
-    const extraPath = extra ? `/${extra.replace(/^\//, '')}` : '';
-    const url = `${base}${extraPath}/stream/series/${imdbId}:${season}:${episode}.json`;
+    const extraPath = extra
+      ? `/${extra.replace(/^\//, '').replace(/\|/g, '%7C')}`
+      : '';
+    const encodedId = `${imdbId}:${season}:${episode}`.replace(/:/g, '%3A');
+    const url = `${base}${extraPath}/stream/series/${encodedId}.json`;
     try {
       const { streams } = await fetch(url).then(r => r.json());
       if (streams?.length) {


### PR DESCRIPTION
## Summary
- properly encode addon extras and episode identifiers when forming stream URLs

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68506e17b9248323a11576778caa4c44