### PR TITLE
Handle failing addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ ORION_EXTRA=
 MEDIAFUSION_EXTRA=
 ```
 
-Some add-ons require tokens or API keys. Provide them in the `*_EXTRA` variables if necessary.
+Some add-ons require tokens or API keys. Provide them in the `*_EXTRA` variables if necessary. If a variable is left blank (or omitted) the corresponding add-on will be skipped. This is useful for sources like `orion` or `mediafusion` which may not respond correctly in some environments.
 
 ## Network Restrictions
 

--- a/src/api/addons.ts
+++ b/src/api/addons.ts
@@ -9,27 +9,35 @@ import {
 type Addon = { base: string; extra: string };
 
 export const addons: Record<string, Addon> = {
-  peerflix   : {
-    base : 'https://peerflix-addon.onrender.com',
-    extra: PEERFLIX_EXTRA || 'language=es|sort=language-desc'
+  peerflix: {
+    base: 'https://peerflix-addon.onrender.com',
+    extra: PEERFLIX_EXTRA || 'language=es|sort=language-desc',
   },
-  torrentio  : {
-    base : 'https://torrentio.strem.fun',
-    extra: TORRENTIO_EXTRA || 'providers=yts,eztv,rarbg,1337x,thepiratebay,kickasstorrents,torrentgalaxy,magnetdl,horriblesubs,nyaasi,tokyotosho,anidex,mejortorrent,wolfmax4k|language=spanish'
+  torrentio: {
+    base: 'https://torrentio.strem.fun',
+    extra:
+      TORRENTIO_EXTRA ||
+      'providers=yts,eztv,rarbg,1337x,thepiratebay,kickasstorrents,torrentgalaxy,magnetdl,horriblesubs,nyaasi,tokyotosho,anidex,mejortorrent,wolfmax4k|language=spanish',
   },
-  thepirate  : {
-    base : 'https://thepiratebay-plus.strem.fun',
-    extra: PIRATEBAY_EXTRA || ''
+  thepirate: {
+    base: 'https://thepiratebay-plus.strem.fun',
+    extra: PIRATEBAY_EXTRA || '',
   },
-  orion      : {
-    base : 'https://5a0d1888fa64-orion.baby-beamup.club',
-    extra: ORION_EXTRA || 'eyJhcGkiOiJHVUYzOUNHSlNFQjdIU0Q1S1BDQ0xBNEtLN0xNR0Y4VSIsImxpbmtMaW1pdCI6IjMiLCJzb3J0VmFsdWUiOiJzdHJlYW1zZWVkcyIsImF1ZGlvY2hhbm5lbHMiOiIyLDYsOCIsInZpZGVvcXVhbGl0eSI6ImhkNGssaGQyayxoZDEwODAsaGQ3MjAsc2QiLCJsaXN0T3B0IjoidG9ycmVudCIsImRlYnJpZHNlcnZpY2VzIjpbXSwiYXVkaW9sYW5ndWFnZXMiOlsiZXMiXSwiYWRkaXRpb25hbFBhcmFtZXRlcnMiOiIifQ'
-  },
-  mediafusion: {
-    base : 'https://mediafusion.elfhosted.com',
-    extra: MEDIAFUSION_EXTRA || 'D-MwAHYWyoinQmo7680dnCraVcidbZz5sCQlR2x6zEztLCSbGTWP_5BlcCkQO9jV557OvY03MPejeGv1EF8v-sIA63smTh00psMEmuKMLW0oY'
-  }
 };
+
+if (ORION_EXTRA) {
+  addons.orion = {
+    base: 'https://5a0d1888fa64-orion.baby-beamup.club',
+    extra: ORION_EXTRA,
+  };
+}
+
+if (MEDIAFUSION_EXTRA) {
+  addons.mediafusion = {
+    base: 'https://mediafusion.elfhosted.com',
+    extra: MEDIAFUSION_EXTRA,
+  };
+}
 
 export function setAddonExtra(key: keyof typeof addons, extra: string) {
   addons[key].extra = extra;


### PR DESCRIPTION
## Summary
- make orion and mediafusion optional
- explain how to disable an addon in README

## Testing
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685076ca12c08323881474589791d367