### PR TITLE
Show add‑on errors and list all streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ Addon failed https://peerflix.mov SyntaxError: JSON Parse error: Unexpected char
 ```
 
 it is likely that the add-on domains are blocked or unreachable from your network. The testing environment for this repository blocks those URLs, so no stream options will be listed. Ensure your connection allows requests to the add-on hosts and that the extra tokens are correctly set.
+
+When add-on requests fail, the Streams screen will now display the error messages so you can easily diagnose connectivity issues.

--- a/src/api/streams.ts
+++ b/src/api/streams.ts
@@ -9,12 +9,18 @@ export interface Stream {
   language?: LanguageTag;
 }
 
+export interface StreamsResult {
+  streams: Stream[];
+  errors: string[];
+}
+
 export async function getEpisodeStreams(
   imdbId: string,
   season: number,
   episode: number,
-) {
+): Promise<StreamsResult> {
   const collected: Stream[] = [];
+  const errors: string[] = [];
 
   const tasks = Object.values(addons).map(async ({ base, extra }) => {
     const extraPath = extra
@@ -33,7 +39,9 @@ export async function getEpisodeStreams(
         );
       }
     } catch (err) {
-      console.warn('Addon failed', base, err?.toString?.());
+      const msg = `Addon failed ${base} ${err?.toString?.()}`;
+      console.warn(msg);
+      errors.push(msg);
     }
   });
 
@@ -47,5 +55,5 @@ export async function getEpisodeStreams(
     const key = s.url ?? s.infoHash ?? Math.random().toString();
     if (!uniq.has(key)) uniq.set(key, s);
   }
-  return Array.from(uniq.values()) as Stream[];
+  return { streams: Array.from(uniq.values()) as Stream[], errors };
 }

--- a/src/screens/Streams.tsx
+++ b/src/screens/Streams.tsx
@@ -19,16 +19,15 @@ function toMagnet(s: any) {
 export default function StreamsScreen({ route }: Props) {
   const { imdbId, season, episode, title } = route.params;
   const [streams, setStreams] = useState<Stream[]>([]);
+  const [errors, setErrors] = useState<string[]>([]);
   const [message, setMessage] = useState<string>('No streams yet…');
 
   useEffect(() => {
     getEpisodeStreams(imdbId, season, episode)
-      .then(all => {
-        const filtered = all.filter(s =>
-          s.language === 'es' || s.language === 'en' || s.language === 'multi'
-        );
-        setStreams(filtered);
-        if (!filtered.length) {
+      .then(({ streams: list, errors }) => {
+        setStreams(list);
+        setErrors(errors);
+        if (!list.length) {
           setMessage(
             'No se encontraron streams. Comprueba la conexión o si los add-ons están bloqueados.'
           );
@@ -63,7 +62,14 @@ export default function StreamsScreen({ route }: Props) {
             </Text>
         </TouchableOpacity>
         )}
-      ListHeaderComponent={<Text style={{ color: '#aaa', padding: 16 }}>{title}</Text>}
+      ListHeaderComponent={
+        <>
+          <Text style={{ color: '#aaa', padding: 16 }}>{title}</Text>
+          {errors.map((e, i) => (
+            <Text key={i} style={{ color: '#f66', paddingHorizontal: 16 }}>{e}</Text>
+          ))}
+        </>
+      }
       ListEmptyComponent={
         <Text style={{ color: '#888', padding: 16 }}>{message}</Text>
       }


### PR DESCRIPTION
## Summary
- surface add-on errors from `getEpisodeStreams`
- display the errors in the Streams screen
- stop filtering streams by language
- document the new behaviour in the README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685078c95b4883239155fbe447cda6aa