### PR TITLE
Show language in torrent listings

### DIFF
--- a/src/api/streams.ts
+++ b/src/api/streams.ts
@@ -7,6 +7,12 @@ export interface Stream {
   infoHash?: string;
   fileIdx?: number;
   language?: LanguageTag;
+  /**
+   * Additional properties returned by the add-on. These could include
+   * quality, seeders, size or any other custom field. We keep them so the
+   * UI can display extra information when present.
+   */
+  [key: string]: any;
 }
 
 export interface StreamsResult {

--- a/src/screens/Streams.tsx
+++ b/src/screens/Streams.tsx
@@ -7,6 +7,18 @@ import * as Clipboard from 'expo-clipboard';
 
 type Props = NativeStackScreenProps<RootStackParamList, 'Streams'>;
 
+// Create a short textual description for a torrent stream
+function describeStream(s: Stream) {
+  const parts: string[] = [];
+  if (s.name) parts.push(s.name);
+  if (s.language) parts.push(`[${s.language.toUpperCase()}]`);
+  const extra = Object.entries(s)
+    .filter(([k]) => !['name', 'language', 'url', 'infoHash', 'fileIdx'].includes(k))
+    .map(([k, v]) => `${k}: ${v}`);
+  if (extra.length) parts.push(extra.join(' · '));
+  return parts.join(' · ');
+}
+
 function toMagnet(s: any) {
   if (s.url) return s.url;                          // magnet o http torrent
   if (s.infoHash) {
@@ -56,10 +68,7 @@ export default function StreamsScreen({ route }: Props) {
             style={{ padding: 16, borderBottomWidth: 1, borderColor: '#333' }}
             onPress={() => copy(item)}
         >
-            <Text style={{ color: '#fff' }}>
-            {item.name ?? item.url ?? item.infoHash}
-            {item.language && ` [${item.language.toUpperCase()}]`}
-            </Text>
+            <Text style={{ color: '#fff' }}>{describeStream(item)}</Text>
         </TouchableOpacity>
         )}
       ListHeaderComponent={


### PR DESCRIPTION
## Summary
- allow Stream objects to keep extra fields
- add helper to describe torrent streams
- show language and extra properties in stream list

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68508486564c83238379308dc01bf13f